### PR TITLE
env_common.c: do not store default mac address with quotes

### DIFF
--- a/uboot-5.x.x.x/common/env_common.c
+++ b/uboot-5.x.x.x/common/env_common.c
@@ -86,16 +86,16 @@ uchar default_environment[] = {
 	"loads_echo="	MK_STR(CONFIG_LOADS_ECHO)	"\0"
 #endif
 #ifdef	CONFIG_ETHADDR
-	"ethaddr="	MK_STR(CONFIG_ETHADDR)		"\0"
+	"ethaddr="	CONFIG_ETHADDR			"\0"
 #endif
 #ifdef	CONFIG_ETH1ADDR
-	"eth1addr="	MK_STR(CONFIG_ETH1ADDR)		"\0"
+	"eth1addr="	CONFIG_ETH1ADDR			"\0"
 #endif
 #ifdef	CONFIG_ETH2ADDR
-	"eth2addr="	MK_STR(CONFIG_ETH2ADDR)		"\0"
+	"eth2addr="	CONFIG_ETH2ADDR			"\0"
 #endif
 #ifdef	CONFIG_ETH3ADDR
-	"eth3addr="	MK_STR(CONFIG_ETH3ADDR)		"\0"
+	"eth3addr="	CONFIG_ETH3ADDR			"\0"
 #endif
 #ifdef	CONFIG_IPADDR
 	"ipaddr=" MK_STR(CONFIG_IPADDR)		"\0"


### PR DESCRIPTION
CONFIG_ETHADDR defines mac address as "xx:xx:xx:xx:xx:xx" and MK_STR stores it with quotes.
Env parser later detects first quote as delimiter, so actual mac address used by ethernet interface was 00:xx:xx:xx:xx:xx
Just remove MK_STR in such case.